### PR TITLE
Allow passing a DOM node or selector

### DIFF
--- a/js/styleselect.js
+++ b/js/styleselect.js
@@ -158,7 +158,7 @@
 			return
 		}
 
-		var realSelect = query(selector),
+		var realSelect = typeof selector == 'object' ? selector : query(selector),
 			realOptions = realSelect.children,
 			selectedIndex = realSelect.selectedIndex,
 			uuid = makeUUID(),


### PR DESCRIPTION
It might be worth adding a bit more checking to see if what is passed is actually a DOM node and not just a plain object. But I don't foresee anyone trying to pass a plain object anyway.